### PR TITLE
Modify the remit mixin to support lists of sizes.

### DIFF
--- a/sass/base/mixins/_maths.scss
+++ b/sass/base/mixins/_maths.scss
@@ -12,9 +12,18 @@
 
 // rem + px fallback
 
-@mixin remit($propery, $size){
-	#{$propery}: #{$size}px;
-	#{$propery}: #{$size/$doc-font-size}rem;
+@mixin remit($property, $sizes) {
+  $rems: ();
+  $pxs: ();
+  
+  @for $i from 1 through length($sizes) {
+    $size: nth($sizes, $i);
+    $pxs: join($pxs, #{$size}px);
+    $rems: join($rems, #{$size/$doc-font-size}rem);
+  }
+  
+  #{$property}: $pxs;
+  #{$property}: $rems;
 }
 
 // making simple squares

--- a/sass/base/mixins/_maths.scss
+++ b/sass/base/mixins/_maths.scss
@@ -13,17 +13,17 @@
 // rem + px fallback
 
 @mixin remit($property, $sizes) {
-  $rems: ();
-  $pxs: ();
-  
-  @for $i from 1 through length($sizes) {
-    $size: nth($sizes, $i);
-    $pxs: join($pxs, #{$size}px);
-    $rems: join($rems, #{$size/$doc-font-size}rem);
-  }
-  
-  #{$property}: $pxs;
-  #{$property}: $rems;
+	$rems: ();
+	$pxs: ();
+
+	@for $i from 1 through length($sizes) {
+		$size: nth($sizes, $i);
+		$pxs: join($pxs, #{$size}px);
+		$rems: join($rems, #{$size/$doc-font-size}rem);
+	}
+
+	#{$property}: $pxs;
+	#{$property}: $rems;
 }
 
 // making simple squares


### PR DESCRIPTION
I've been using Sassifaction for a while, and found myself doing stuff like:

``` scss
.foo {
    @include remit(padding, 20);
    @include remit(padding-left, 10);
    @include remit(padding-right, 10);
}
```

I thought it'd be handy if the mixin could handle lists of sizes, so you can do something like:

``` scss
.foo {
    @include remit(padding, 20 10);
}
```
