### PR TITLE
Added ability to change placeholder opacity

### DIFF
--- a/sass/base/mixins/_placeholder.scss
+++ b/sass/base/mixins/_placeholder.scss
@@ -1,14 +1,17 @@
-@mixin placeholder ($placeholder-color) {
-	&::webkit-input-placeholder {
-		color: $placeholder-color;
-	}
+@mixin placeholder($color: $text-color, $alpha: .8) {
+	&::-webkit-input-placeholder {
+		color: rgba($color, $alpha);
+	}  /* WebKit browsers */
+
 	&:-moz-placeholder {
-		color: $placeholder-color;
-	}
+		color: rgba($color, 1)
+	}  /* Mozilla Firefox 4 to 18 */
+
 	&::-moz-placeholder {
-		color: $placeholder-color;
-	}
+		color: rgba($color, 1)
+	}  /* Mozilla Firefox 19+ */
+
 	&:-ms-input-placeholder {
-		color: $placeholder-color;
-	}
+		color: rgba($color, $alpha)
+	} /* Internet Explorer 10+ */
 }


### PR DESCRIPTION
This is my first 'Fork' so not sure if I have done it right?
I have added the ability to change the opacity of the placeholder text as well as extending this so you can actually change the color of the placholder on :focus.

For Example;

input[type=text] {
   @include placeholder($text-color);

   &:focus {
       @include placeholder($white);
       background-color: $base-color;
   }
}
