### PR TITLE
RGBA fallback fix

### DIFF
--- a/sass/base/mixins/_colors.scss
+++ b/sass/base/mixins/_colors.scss
@@ -29,13 +29,14 @@
 }
 
 @function trans($color, $percentage) {
-  @return lighten($color, (1-$percentage)*5%);
+  @return lighten($color, (1-$percentage)*50%);
 }
 @function transd($color, $percentage) {
-  @return darken($color, (1-$percentage)*5%);
+  @return darken($color, (1-$percentage)*50%);
 }
-@mixin tran($type, $color, $percentage, $shade: ligthen) {
-  @if $shade == lighten {
+
+@mixin tran($type, $color, $percentage, $darken: n) {
+  @if $darken == n {
     @if $type == color {
       color: trans($color, $percentage);
       color: rgba($color, $percentage);


### PR DESCRIPTION
The 5% multiple returns a tenth of  the intended percentage - 4.5%
instead of 45%. Changing it to 50% corrects this. Also, replace the
`$shade: lighten` with `$darken: true`. Seems simpler that way IMHO. 
